### PR TITLE
Android: Update 3.0.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,11 +43,11 @@ thank you!
 
 ##### `signInAndRetrieveDataWithCredential(parameters)` (Dictionary, iOS-only)
 
-##### `sendPasswordResetWithEmail(parameters)` (Dictionary, iOS-only)
+##### `sendPasswordResetWithEmail(parameters)` (Dictionary)
 
 ##### `confirmPasswordResetWithCode(parameters)` (Dictionary, iOS-only)
 
-##### `checkActionCode(parameters)` (Dictionary, iOS-only)
+##### `checkActionCode(parameters)` (Dictionary)
 
 ##### `verifyPasswordResetCode(parameters)` (Dictionary, iOS-only)
 
@@ -67,7 +67,7 @@ thank you!
 
 ##### `currentUser` (Dictionary, get)
 
-##### `languageCode` (String, get, iOS-only)
+##### `languageCode` (String, get)
 
 ##### `apnsToken` (Ti.Blob, get, iOS-only)
 
@@ -75,24 +75,43 @@ thank you!
 
 ### FirebaseAuth.AuthCredential
 
-Virtual Type to be used in ``signInWithCredential`. Create with `createCredential(parameters)`.
+Virtual Type to be used in `signInWithCredential`. Create with `createCredential(parameters)`.
 
 ## Example
 ```js
 // Require the Firebase Auth module
 var FirebaseAuth = require('firebase.auth');
 
+
+// Sign-up
+FirebaseAuth.createUserWithEmail({
+	email: 'john@doe.com',
+	password: 't1r0ck$!',
+	callback: function(e) {
+		if (!e.success) {
+			Ti.API.error('Create: error: ' + JSON.stringify(e));
+			return;
+		}
+
+		Ti.API.info('Create: success!');
+		Ti.API.info(JSON.stringify(e.user));
+	}
+});
+
+
+// Login
 FirebaseAuth.signInWithEmail({
   email: 'john@doe.com',
   password: 't1r0ck$!',
   callback: function(e) {
     if (!e.success) {
-      Ti.API.error('Error: ' + e.error);
+      Ti.API.error('Error: ' + JSON.stringify(e));
       return;
     }
 
     Ti.API.info('Success!');
-    Ti.API.info(e.user);
+    Ti.API.info(JSON.stringify(e.user));	// e.g.  {"uid":"...","photoURL":null,"phoneNumber":null,"email":"...","providerID":"...","displayName":null}
+
   }
 });
 

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -5,6 +5,5 @@ repositories {
 
 
 dependencies {
-	implementation 'com.google.firebase:firebase-auth:19.3.0'
-	implementation 'com.google.firebase:firebase-auth-interop:19.0.0'
+	implementation 'com.google.firebase:firebase-auth:20.0.1'
 }

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -5,5 +5,5 @@ repositories {
 
 
 dependencies {
-	implementation 'com.google.firebase:firebase-auth:20.0.1'
+	implementation 'com.google.firebase:firebase-auth:20.0.2'
 }

--- a/android/manifest
+++ b/android/manifest
@@ -2,7 +2,7 @@
 # this is your module manifest and used by Titanium
 # during compilation, packaging, distribution, etc.
 #
-version: 3.0.0
+version: 3.0.1
 apiversion: 4
 architectures: arm64-v8a armeabi-v7a x86 x86_64
 description: titanium-firebase-auth

--- a/android/src/firebase/auth/TitaniumFirebaseAuthCredentialProxy.java
+++ b/android/src/firebase/auth/TitaniumFirebaseAuthCredentialProxy.java
@@ -11,14 +11,12 @@ package firebase.auth;
 import com.google.firebase.auth.AuthCredential;
 import com.google.firebase.auth.EmailAuthProvider;
 import com.google.firebase.auth.FacebookAuthProvider;
-import com.google.firebase.auth.FirebaseAuth;
 import com.google.firebase.auth.GithubAuthProvider;
 import com.google.firebase.auth.GoogleAuthProvider;
 import com.google.firebase.auth.OAuthProvider;
-import com.google.firebase.auth.PhoneAuthCredential;
 import com.google.firebase.auth.PhoneAuthProvider;
 import com.google.firebase.auth.TwitterAuthProvider;
-import org.appcelerator.kroll.KrollDict;
+
 import org.appcelerator.kroll.KrollProxy;
 import org.appcelerator.kroll.annotations.Kroll;
 import org.appcelerator.kroll.common.Log;

--- a/android/src/firebase/auth/TitaniumFirebaseAuthModule.java
+++ b/android/src/firebase/auth/TitaniumFirebaseAuthModule.java
@@ -9,6 +9,7 @@
 package firebase.auth;
 
 import android.app.Activity;
+import android.drm.DrmStore;
 import android.os.Bundle;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
@@ -18,6 +19,7 @@ import com.google.android.gms.tasks.OnCompleteListener;
 import com.google.android.gms.tasks.OnFailureListener;
 import com.google.android.gms.tasks.OnSuccessListener;
 import com.google.android.gms.tasks.Task;
+import com.google.firebase.auth.ActionCodeResult;
 import com.google.firebase.auth.AuthResult;
 import com.google.firebase.auth.FirebaseAuth;
 import com.google.firebase.auth.FirebaseUser;
@@ -222,6 +224,27 @@ public class TitaniumFirebaseAuthModule extends KrollModule
 				callback.callAsync(getKrollObject(), event);
             }
         });
+	}
+
+	@Kroll.method
+	public void checkActionCode(KrollDict params)
+	{
+		String code = (String) params.get("code");
+		final KrollFunction callback = (KrollFunction) params.get("callback");
+
+		mAuth.checkActionCode(code).addOnCompleteListener(new OnCompleteListener<ActionCodeResult>() {
+			@Override
+			public void onComplete(Task<ActionCodeResult> task) {
+				KrollDict event = new KrollDict();
+				if (task.isSuccessful()) {
+					event.put("success", task.isSuccessful());
+					event.put("operation", task.getResult().getOperation());
+				} else {
+					event.put("success", false);
+				}
+				callback.callAsync(getKrollObject(), event);
+			}
+		});
 	}
 
 	@Kroll.method


### PR DESCRIPTION
* Update version to 20.0.1
* fixed some README parts where it says iOS-only but the functions are there for Android
* added `sign up` and `login` example
* added `checkActionCode` for Android
* removed unused imports

Tested it with ti.playservices 17.5.0 + firebase.core 6.0.1 (other open PR) -> Create + Login working fine

[firebase.auth-android-3.0.1.zip](https://github.com/hansemannn/titanium-firebase-auth/files/5826643/firebase.auth-android-3.0.1.zip)
